### PR TITLE
Remove --broken flag when invoking git version

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -125,7 +125,7 @@ _fetch_version() {
 	doc_version="<UNKNOWN>"
 	if which git &> /dev/null && git rev-parse --is-inside-work-tree &> /dev/null
 	then
-		doc_version="$(git describe --always --dirty --broken)"
+		doc_version="$(git describe --always --dirty)"
 	fi
 	echo "$doc_version"
 }


### PR DESCRIPTION
This is only available since 2.13.7. I am on Ubuntu 16.04 which ships 2.7.4. We could do some advanced bash stuff to figure out the version but it doesn't seem worth it.